### PR TITLE
fix: repo-wide Python2 except-syntax bugs + black py314 target bug

### DIFF
--- a/backend/app/core/providers/generic.py
+++ b/backend/app/core/providers/generic.py
@@ -670,7 +670,7 @@ class GenericProvider(BaseProvider):
                 if year_elem:
                     try:
                         year = int(year_elem.text.strip())
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         pass
 
                 # Detect NSFW based on content
@@ -1249,7 +1249,7 @@ class GenericProvider(BaseProvider):
                     context={"url": page_url, "attempt": attempt + 1},
                 )
 
-            except AntiBotError, ContentError:
+            except (AntiBotError, ContentError):
                 # Re-raise these immediately
                 raise
 

--- a/backend/app/core/providers/madaradex.py
+++ b/backend/app/core/providers/madaradex.py
@@ -254,7 +254,7 @@ class MadaraDexProvider(BaseProvider):
                     rating_match = re.search(r"(\d+(?:\.\d+)?)", rating_text)
                     if rating_match:
                         details["rating"] = float(rating_match.group(1))
-                except ValueError, AttributeError:
+                except (ValueError, AttributeError):
                     pass
 
             return details

--- a/backend/app/core/services/download_clients.py
+++ b/backend/app/core/services/download_clients.py
@@ -395,7 +395,7 @@ class SABnzbdClient(BaseDownloadClient):
                 }
 
                 return int(value * multipliers.get(unit, 1))
-        except ValueError, KeyError:
+        except (ValueError, KeyError):
             pass
 
         return 0
@@ -405,7 +405,7 @@ class SABnzbdClient(BaseDownloadClient):
         try:
             # SABnzbd returns speed in KB/s
             return int(float(speed_str) * 1024)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return 0
 
     async def _check_history(self, external_id: str) -> Dict[str, Any]:

--- a/backend/app/core/services/enhanced_search.py
+++ b/backend/app/core/services/enhanced_search.py
@@ -284,7 +284,7 @@ class EnhancedSearchService:
 
                 duration = time.perf_counter() - start_time
                 logger.info(
-                    f"[DEBUG] Processed result {i+1}/{len(mu_results['results'])} ({mu_result['record']['series_id']}) in {duration:.2f}s"
+                    f"[DEBUG] Processed result {i + 1}/{len(mu_results['results'])} ({mu_result['record']['series_id']}) in {duration:.2f}s"
                 )
 
             except Exception as e:

--- a/backend/app/core/services/integrations/anilist_client.py
+++ b/backend/app/core/services/integrations/anilist_client.py
@@ -340,5 +340,5 @@ class AnilistClient(BaseIntegrationClient):
         try:
             date = datetime(date_obj["year"], date_obj["month"], date_obj["day"])
             return date.isoformat()
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return None

--- a/backend/app/core/services/mangaupdates.py
+++ b/backend/app/core/services/mangaupdates.py
@@ -393,7 +393,7 @@ class MangaUpdatesService:
             # Handle string year like '1997'
             try:
                 return int(year_data)
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 return None
         return None
 

--- a/backend/app/core/services/storage_recovery.py
+++ b/backend/app/core/services/storage_recovery.py
@@ -121,7 +121,7 @@ class StorageRecoveryService:
                     filepath = os.path.join(dirpath, filename)
                     try:
                         total_size += os.path.getsize(filepath)
-                    except OSError, IOError:
+                    except (OSError, IOError):
                         continue
         except Exception as e:
             logger.error(f"Error calculating directory size for {directory_path}: {e}")

--- a/backend/app/core/services/tiered_indexing.py
+++ b/backend/app/core/services/tiered_indexing.py
@@ -608,7 +608,7 @@ class MadaraDexIndexer(BaseIndexer):
                 rating_text = rating_elem.get_text(strip=True)
                 try:
                     rating = float(rating_text)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
 
             # Check for NSFW indicators

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,7 +26,7 @@ Issues = "https://github.com/Futs/kuroibara/issues"
 # Backend Python formatting and linting configuration
 [tool.black]
 line-length = 88
-target-version = ['py314']
+target-version = ['py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/backend/tests/test_enhanced_tiered_search.py
+++ b/backend/tests/test_enhanced_tiered_search.py
@@ -412,7 +412,7 @@ class TestErrorHandling:
             entry = service._create_entry_from_metadata(None)
             # If it doesn't raise an exception, that's fine
             assert entry is None
-        except AttributeError, TypeError:
+        except (AttributeError, TypeError):
             # If it raises an exception for None input, that's also acceptable
             pass
 


### PR DESCRIPTION
Found 9 instances total (only 1 of which I'd previously fixed) of the Python2 `except X, Y:` syntax across generic.py, madaradex.py, download_clients.py (x2), anilist_client.py, mangaupdates.py, storage_recovery.py, tiered_indexing.py, and a test file - all invalid in Python 3, all would crash on import.

These went undetected locally all session because the running dev container was using a stale __pycache__ .pyc compiled before the bug existed, so the broken source on disk was never actually re-parsed. CI builds fresh with no cache, which is exactly why `black --check`/ `flake8` caught it there and not here.

Root cause of why my very first fix (tiered_indexing.py, commit 816e3bb) silently reverted itself: pyproject.toml pinned `target-version = ['py314']` for black, and black has a reproducible bug under that specific target where it rewrites a correctly parenthesized `except (A, B):` back into the invalid unparenthesized form. Confirmed reproducible in isolation and confirmed it goes away under `target-version = ['py312']` - which also happens to match the Python version CI's black/flake8 job actually runs under, and matches the warning CI itself printed ("set --target-version to py312").

Also fixed an E226 flake8 finding (missing whitespace around an arithmetic operator) in enhanced_search.py.

Verified: black --check, isort --check-only, and flake8 all pass clean on every tracked file; full test suite passes (204 passed, 6 skipped).